### PR TITLE
Fix dashboard login redirect

### DIFF
--- a/Forms/Dashboard.aspx.cs
+++ b/Forms/Dashboard.aspx.cs
@@ -8,7 +8,8 @@ namespace PROYECTOFINAL.Forms
         {
             if (Session["cedula"] == null || Session["nivel"] == null)
             {
-                Response.Redirect("~/Login.aspx");
+                // Redirige correctamente al formulario de inicio de sesión cuando no hay sesión activa
+                Response.Redirect("~/Forms/Login.aspx");
                 return;
             }
 
@@ -33,7 +34,8 @@ namespace PROYECTOFINAL.Forms
                     break;
 
                 default:
-                    Response.Redirect("~/Login.aspx");
+                    // Si el rol no es reconocido, regresar a la página de login
+                    Response.Redirect("~/Forms/Login.aspx");
                     return;
             }
 


### PR DESCRIPTION
## Summary
- Correct dashboard's session check to redirect to existing login form

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68978420d41c83329ed857bd5c99d7f1